### PR TITLE
Adjustments for stashes

### DIFF
--- a/gamedata/scripts/roguelite_module_placeables.script
+++ b/gamedata/scripts/roguelite_module_placeables.script
@@ -11,7 +11,6 @@ local config = {
 local placeable_objects_section_names = {
     "placeable_radio",
     "placeable_piano",
-	"placeable_fridge",
 	"placeable_clinic_equipments",
 	"placeable_suit",
 	"placeable_rug",
@@ -76,7 +75,6 @@ local placeable_objects_section_names = {
 	"placeable_med_case_1",
 	"placeable_exo_repair_kit_item",
 	"placeable_case_item",
-	"placeable_box_paper",
 	"placeable_documents_1",
 	"placeable_documents_2",
 	"placeable_notes_writing_book",
@@ -105,7 +103,6 @@ local placeable_objects_section_names = {
 	"placeable_psi_helmet",
 	"placeable_stool",
 	"placeable_teapot",
-	"placeable_cans_tuna",
 	"placeable_dish1",
 	"placeable_dish2",
 	"placeable_laptop_item",
@@ -114,14 +111,6 @@ local placeable_objects_section_names = {
 	"placeable_shower",
 	"placeable_sink",
 	"placeable_toilet",
-	"placeable_storage01",
-	"placeable_storage02",
-	"placeable_storage03",
-	"placeable_storage04",
-	"placeable_storage05",
-	"placeable_storage06",
-	"placeable_storage07",
-	"placeable_storage08",
 	"placeable_wooden_plank",
 	"placeable_door",
 	"placeable_door02",
@@ -138,7 +127,6 @@ local placeable_objects_section_names = {
 	"placeable_shield",
 	"placeable_metal_plate",
 	"placeable_wooden_board",
-	"placeable_arti_display",
 }
 
 local m_data = {

--- a/gamedata/scripts/roguelite_module_stashes.script
+++ b/gamedata/scripts/roguelite_module_stashes.script
@@ -10,6 +10,21 @@ local placeable_containers_section_names = {
     "placeable_blue_box",
     "placeable_exo_repair_kit",
     "placeable_sumka6",
+	"placeable_fridge",
+	"placeable_cans_tuna",
+	"placeable_prop_ammo_box",
+	"placeable_prop_med_case_1",
+	"placeable_stove2_stash",
+	"placeable_arti_display",
+	"placeable_storage01",
+	"placeable_storage02",
+	"placeable_storage03",
+	"placeable_storage04",
+	"placeable_storage05",
+	"placeable_storage06",
+	"placeable_storage07",
+	"placeable_storage08",
+	"placeable_box_paper",
     "workshop_stash"
 }
 


### PR DESCRIPTION
The following stash items have been confirmed to persist:

inv_backpack (Backpack)
placeable_case (Gun Case)
placeable_blue_box (Metal Box)
placeable_exo_repair_kit (Empty Exoskeleton Repair Kit)
placeable_sumka6 (Small Backpack)
placeable_fridge (Old Fridge)
placeable_prop_ammo_box (Ammo Box)
placeable_prop_med_case_1 (Medical Case)
placeable_storage01 (Metal Storage Container)
placeable_storage02 (Large Metal Storage Container)
placeable_storage03 (Green Metal Box)
placeable_storage04 (Small Safe)
placeable_storage05 (Toolbox)
placeable_storage06(Green Chest)
placeable_storage07 (Locker)
placeable_storage08 (Large Safe)
placeable_box_paper (Cardboard Box)
workshop_stash (Portable Workshop)



The following stashes have not yet been confirmed to persist:

placeable_cans_tuna (Canned Food Crate)
placeable_stove2_stash (Large Stove - NOTE this one may be a little odd there seems to be a separate prop for the stove)
placeable_arti_display (Artifacts Display)



Not Added Yet:

placeable_weapon_rack (Gun Display Rack)
placeable_pistol_shelf (Pistol Display Shelf)